### PR TITLE
Update OWNERS + Fix broken HTML

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,20 @@
 approvers:
+- munnerz
 - joshvanl
+- meyskens
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+- jahrlin
 reviewers:
+- munnerz
 - joshvanl
+- meyskens
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+- jahrlin

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-<p align="center"><img src="https://github.com/jetstack/cert-manager/blob/master/logo/logo.png" width="250x" /></p>
-</a>
-<a href="https://godoc.org/github.com/cert-manager/trust"><img src="https://godoc.org/github.com/cert-manager/trust?status.svg"></a>
-<a href="https://goreportcard.com/report/github.com/cert-manager/trust"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/trust" /></a></p>
+<p align="center">
+  <img src="https://github.com/jetstack/cert-manager/blob/master/logo/logo.png" width="250x" alt="cert-manager project logo" />
+</p>
+<p align="center">
+  <a href="https://godoc.org/github.com/cert-manager/trust"><img src="https://godoc.org/github.com/cert-manager/trust?status.svg" alt="cert-manager/trust godoc"></a>
+  <a href="https://goreportcard.com/report/github.com/cert-manager/trust"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/trust" /></a>
+  <a href="https://artifacthub.io/packages/search?repo=cert-manager"><img alt="Artifact Hub" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager" /></a>
+</p>
 
 # trust
 

--- a/deploy/charts/trust/Chart.yaml
+++ b/deploy/charts/trust/Chart.yaml
@@ -6,8 +6,8 @@ description: A Helm chart for cert-manager-trust
 
 home: https://github.com/cert-manager/trust
 maintainers:
-- name: joshvanl
-  email: joshua.vanleeuwen@jetstack.io
+- name: cert-manager-maintainers
+  email: cert-manager-maintainers@googlegroups.com
   url: https://cert-manager.io
 sources:
 - https://github.com/cert-manager/trust

--- a/deploy/charts/trust/README.md
+++ b/deploy/charts/trust/README.md
@@ -8,9 +8,9 @@ A Helm chart for cert-manager-trust
 
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| joshvanl | joshua.vanleeuwen@jetstack.io | https://cert-manager.io |
+|           Name           |                   Email                   |          URL            |
+| ------------------------ | ----------------------------------------- | ----------------------- |
+| cert-manager maintainers | cert-manager-maintainers@googlegroups.com | https://cert-manager.io |
 
 ## Source Code
 


### PR DESCRIPTION
Should be automated, but this harmonizes the OWNERS file with the main cert-manager file, and updates the helm chart too. The helm chart update won't take effect until after another release - it's probably not worth doing a release straight away just for this, though.

Also, as part of [this PR for istio-csr](https://github.com/cert-manager/istio-csr/pull/116) I noticed that the header on a lot of our READMEs included invalid HTML. This fixes that, adds an artifacthub badge, and adds alt text for a11y.