### PR TITLE
Makefile: go vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,13 @@ all: depend generate test build image ## runs test, build and image
 test: lint ## test trust
 	KUBEBUILDER_ASSETS=$(BINDIR)/kubebuilder/bin go test -v ./pkg/... ./cmd/...
 
-.PHONY: test
-lint:
+.PHONY: lint
+lint: vet
 	./hack/verify-boilerplate.sh
+
+.PHONY: vet
+vet:
+	go vet ./...
 
 .PHONY: build
 build: ## build trust

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -202,9 +202,12 @@ def get_regexs():
     regexs["year"] = re.compile('YEAR')
     # dates can be 2014, 2015, 2016, or 2017; company holder names can be anything
     regexs["date"] = re.compile('(2014|2015|2016|2017)')
-    # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n",
-                                                re.MULTILINE)
+    # strip the following build constraints/tags:
+    # //go:build
+    # // +build \n\n
+    regexs["go_build_constraints"] = re.compile(
+        r"^(//(go:build| \+build).*\n)+\n", re.MULTILINE)
+
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     return regexs

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -85,11 +85,11 @@ func Test_Reconcile(t *testing.T) {
 			},
 			Spec: trustapi.BundleSpec{
 				Sources: []trustapi.BundleSource{
-					{ConfigMap: &trustapi.SourceObjectKeySelector{sourceConfigMapName, trustapi.KeySelector{Key: sourceConfigMapKey}}},
-					{Secret: &trustapi.SourceObjectKeySelector{sourceSecretName, trustapi.KeySelector{Key: sourceSecretKey}}},
+					{ConfigMap: &trustapi.SourceObjectKeySelector{Name: sourceConfigMapName, KeySelector: trustapi.KeySelector{Key: sourceConfigMapKey}}},
+					{Secret: &trustapi.SourceObjectKeySelector{Name: sourceSecretName, KeySelector: trustapi.KeySelector{Key: sourceSecretKey}}},
 					{InLine: pointer.String("C")},
 				},
-				Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{targetKey}},
+				Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 			},
 		}
 
@@ -102,7 +102,7 @@ func Test_Reconcile(t *testing.T) {
 		}
 
 		fixedTime     = time.Date(2021, 01, 01, 01, 0, 0, 0, time.UTC)
-		fixedmetatime = &metav1.Time{fixedTime}
+		fixedmetatime = &metav1.Time{Time: fixedTime}
 		fixedclock    = fakeclock.NewFakeClock(fixedTime)
 	)
 
@@ -219,7 +219,7 @@ func Test_Reconcile(t *testing.T) {
 		"if Bundle Status Target doesn't match the Spec Target, delete old targets and update": {
 			existingObjects: append(namespaces, sourceConfigMap, sourceSecret,
 				gen.BundleFrom(baseBundle,
-					gen.SetBundleStatus(trustapi.BundleStatus{Target: &trustapi.BundleTarget{&trustapi.KeySelector{"old-target"}}}),
+					gen.SetBundleStatus(trustapi.BundleStatus{Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "old-target"}}}),
 				),
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
@@ -235,7 +235,7 @@ func Test_Reconcile(t *testing.T) {
 			expObjects: append(namespaces, sourceConfigMap, sourceSecret,
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleResourceVersion("1001"),
-					gen.SetBundleStatus(trustapi.BundleStatus{Target: &trustapi.BundleTarget{&trustapi.KeySelector{targetKey}}}),
+					gen.SetBundleStatus(trustapi.BundleStatus{Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}}}),
 				),
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
@@ -256,7 +256,7 @@ func Test_Reconcile(t *testing.T) {
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleResourceVersion("1001"),
 					gen.SetBundleStatus(trustapi.BundleStatus{
-						Target: &trustapi.BundleTarget{&trustapi.KeySelector{targetKey}},
+						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 						Conditions: []trustapi.BundleCondition{
 							{
 								Type:               trustapi.BundleConditionSynced,
@@ -301,7 +301,7 @@ func Test_Reconcile(t *testing.T) {
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleResourceVersion("1001"),
 					gen.SetBundleStatus(trustapi.BundleStatus{
-						Target: &trustapi.BundleTarget{&trustapi.KeySelector{targetKey}},
+						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 						Conditions: []trustapi.BundleCondition{
 							{
 								Type:               trustapi.BundleConditionSynced,
@@ -336,7 +336,7 @@ func Test_Reconcile(t *testing.T) {
 			existingObjects: append(namespaces, sourceConfigMap, sourceSecret,
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleStatus(trustapi.BundleStatus{
-						Target: &trustapi.BundleTarget{&trustapi.KeySelector{targetKey}},
+						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 						Conditions: []trustapi.BundleCondition{
 							{
 								Type:               trustapi.BundleConditionSynced,
@@ -368,7 +368,7 @@ func Test_Reconcile(t *testing.T) {
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleResourceVersion("1001"),
 					gen.SetBundleStatus(trustapi.BundleStatus{
-						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{targetKey}},
+						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 						Conditions: []trustapi.BundleCondition{
 							{
 								Type:               trustapi.BundleConditionSynced,
@@ -423,7 +423,7 @@ func Test_Reconcile(t *testing.T) {
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleResourceVersion("1001"),
 					gen.SetBundleStatus(trustapi.BundleStatus{
-						Target: &trustapi.BundleTarget{&trustapi.KeySelector{targetKey}},
+						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 						Conditions: []trustapi.BundleCondition{
 							{
 								Type:               trustapi.BundleConditionSynced,
@@ -458,7 +458,7 @@ func Test_Reconcile(t *testing.T) {
 			existingObjects: append(namespaces, sourceConfigMap, sourceSecret,
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleStatus(trustapi.BundleStatus{
-						Target: &trustapi.BundleTarget{&trustapi.KeySelector{targetKey}},
+						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 						Conditions: []trustapi.BundleCondition{
 							{
 								Type:               trustapi.BundleConditionSynced,
@@ -490,7 +490,7 @@ func Test_Reconcile(t *testing.T) {
 				gen.BundleFrom(baseBundle,
 					gen.SetBundleResourceVersion("1000"),
 					gen.SetBundleStatus(trustapi.BundleStatus{
-						Target: &trustapi.BundleTarget{&trustapi.KeySelector{targetKey}},
+						Target: &trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 						Conditions: []trustapi.BundleCondition{
 							{
 								Type:               trustapi.BundleConditionSynced,

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -87,7 +87,7 @@ func AddBundleController(ctx context.Context, mgr manager.Manager, opts Options)
 
 				var requests []reconcile.Request
 				for _, bundle := range bundleList.Items {
-					requests = append(requests, reconcile.Request{types.NamespacedName{Name: bundle.Name}})
+					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: bundle.Name}})
 				}
 
 				return requests
@@ -115,7 +115,7 @@ func AddBundleController(ctx context.Context, mgr manager.Manager, opts Options)
 
 						// Bundle references this ConfigMap as a source. Add to request.
 						if source.ConfigMap.Name == obj.GetName() {
-							requests = append(requests, reconcile.Request{types.NamespacedName{Name: bundle.Name}})
+							requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: bundle.Name}})
 							break
 						}
 					}
@@ -147,7 +147,7 @@ func AddBundleController(ctx context.Context, mgr manager.Manager, opts Options)
 
 						// Bundle references this Secret as a source. Add to request.
 						if source.Secret.Name == obj.GetName() {
-							requests = append(requests, reconcile.Request{types.NamespacedName{Name: bundle.Name}})
+							requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: bundle.Name}})
 							break
 						}
 					}

--- a/pkg/bundle/sync_test.go
+++ b/pkg/bundle/sync_test.go
@@ -176,7 +176,7 @@ func Test_syncTarget(t *testing.T) {
 
 			needsUpdate, err := b.syncTarget(context.TODO(), klogr.New(), &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
-				Spec:       trustapi.BundleSpec{Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{key}}},
+				Spec:       trustapi.BundleSpec{Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: key}}},
 			}, namespace, data)
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)
@@ -237,7 +237,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if single ConfigMap source which doesn't exist, return notFoundError": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{"configmap", trustapi.KeySelector{"key"}}},
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects:          []runtime.Object{},
 			expData:          "",
@@ -246,7 +246,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if single ConfigMap source whose key doesn't exist, return notFoundError": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{"configmap", trustapi.KeySelector{"key"}}},
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects:          []runtime.Object{&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "configmap"}}},
 			expData:          "",
@@ -255,7 +255,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if single ConfigMap source, return data": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{"configmap", trustapi.KeySelector{"key"}}},
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -267,7 +267,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if ConfigMap and InLine source, return appended data": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{"configmap", trustapi.KeySelector{"key"}}},
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", KeySelector: trustapi.KeySelector{Key: "key"}}},
 				{InLine: pointer.String("\n\n\nC\n\nD\n\n\n")},
 			}}},
 			objects: []runtime.Object{&corev1.ConfigMap{
@@ -280,7 +280,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if single Secret source exists which doesn't exist, should return not found error": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{"secret", trustapi.KeySelector{"key"}}},
+				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects:          []runtime.Object{},
 			expData:          "",
@@ -289,7 +289,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if single Secret source whose key doesn't exist, return notFoundError": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{"secret", trustapi.KeySelector{"key"}}},
+				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects:          []runtime.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret"}}},
 			expData:          "",
@@ -298,7 +298,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if single Secret source, return data": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{"secret", trustapi.KeySelector{"key"}}},
+				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects: []runtime.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret"},
@@ -310,7 +310,7 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if Secret and InLine source, return appended data": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{"secret", trustapi.KeySelector{"key"}}},
+				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", KeySelector: trustapi.KeySelector{Key: "key"}}},
 				{InLine: pointer.String("\n\n\nC\n\nD\n\n\n")},
 			}}},
 			objects: []runtime.Object{&corev1.Secret{
@@ -323,9 +323,9 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if Secret, ConfigmMap and InLine source, return appended data": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{"configmap", trustapi.KeySelector{"key"}}},
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", KeySelector: trustapi.KeySelector{Key: "key"}}},
 				{InLine: pointer.String("\n\n\nC\n\nD\n\n\n")},
-				{Secret: &trustapi.SourceObjectKeySelector{"secret", trustapi.KeySelector{"key"}}},
+				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects: []runtime.Object{
 				&corev1.ConfigMap{
@@ -343,8 +343,8 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if source Secret exists, but not ConfigMap, return not found error": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{"configmap", trustapi.KeySelector{"key"}}},
-				{Secret: &trustapi.SourceObjectKeySelector{"secret", trustapi.KeySelector{"key"}}},
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", KeySelector: trustapi.KeySelector{Key: "key"}}},
+				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects: []runtime.Object{
 				&corev1.ConfigMap{
@@ -358,8 +358,8 @@ func Test_buildSourceBundle(t *testing.T) {
 		},
 		"if source ConfigMap exists, but not Secret, return not found error": {
 			bundle: &trustapi.Bundle{Spec: trustapi.BundleSpec{Sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{"configmap", trustapi.KeySelector{"key"}}},
-				{Secret: &trustapi.SourceObjectKeySelector{"secret", trustapi.KeySelector{"key"}}},
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", KeySelector: trustapi.KeySelector{Key: "key"}}},
+				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", KeySelector: trustapi.KeySelector{Key: "key"}}},
 			}}},
 			objects: []runtime.Object{
 				&corev1.Secret{

--- a/pkg/bundle/util.go
+++ b/pkg/bundle/util.go
@@ -51,7 +51,7 @@ func bundleHasCondition(bundle *trustapi.Bundle, condition trustapi.BundleCondit
 // LastTransitionTime will not be updated if an existing condition of the same
 // Type and Status already exists.
 func (b *bundle) setBundleCondition(bundle *trustapi.Bundle, condition trustapi.BundleCondition) {
-	condition.LastTransitionTime = &metav1.Time{b.clock.Now()}
+	condition.LastTransitionTime = &metav1.Time{Time: b.clock.Now()}
 	condition.ObservedGeneration = bundle.Generation
 
 	var updatedConditions []trustapi.BundleCondition

--- a/pkg/bundle/util_test.go
+++ b/pkg/bundle/util_test.go
@@ -60,7 +60,7 @@ func Test_bundleHasCondition(t *testing.T) {
 			expectHasCondition: true,
 		},
 		"an existing condition with a different LastTransitionTime should return true still": {
-			existingConditions: []trustapi.BundleCondition{{Reason: "A", ObservedGeneration: bundleGeneration, LastTransitionTime: &metav1.Time{fixedTime.Add(-time.Second)}}},
+			existingConditions: []trustapi.BundleCondition{{Reason: "A", ObservedGeneration: bundleGeneration, LastTransitionTime: &metav1.Time{Time: fixedTime.Add(-time.Second)}}},
 			newCondition:       trustapi.BundleCondition{Reason: "A"},
 			expectHasCondition: true,
 		},
@@ -89,7 +89,7 @@ func Test_setBundleCondition(t *testing.T) {
 	const bundleGeneration int64 = 2
 	var (
 		fixedTime     = time.Date(2021, 01, 01, 01, 0, 0, 0, time.UTC)
-		fixedmetatime = &metav1.Time{fixedTime}
+		fixedmetatime = &metav1.Time{Time: fixedTime}
 		fixedclock    = fakeclock.NewFakeClock(fixedTime)
 	)
 
@@ -175,7 +175,7 @@ func Test_setBundleCondition(t *testing.T) {
 					Status:             corev1.ConditionTrue,
 					Reason:             "B",
 					Message:            "C",
-					LastTransitionTime: &metav1.Time{fixedTime.Add(-time.Second)},
+					LastTransitionTime: &metav1.Time{Time: fixedTime.Add(-time.Second)},
 					ObservedGeneration: bundleGeneration - 1,
 				},
 			},
@@ -192,7 +192,7 @@ func Test_setBundleCondition(t *testing.T) {
 					Status:             corev1.ConditionTrue,
 					Reason:             "B",
 					Message:            "C",
-					LastTransitionTime: &metav1.Time{fixedTime.Add(-time.Second)},
+					LastTransitionTime: &metav1.Time{Time: fixedTime.Add(-time.Second)},
 					ObservedGeneration: bundleGeneration,
 				},
 			},

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -251,16 +251,16 @@ func Test_validateBundle(t *testing.T) {
 				Spec: trustapi.BundleSpec{
 					Sources: []trustapi.BundleSource{
 						{
-							ConfigMap: &trustapi.SourceObjectKeySelector{"test", trustapi.KeySelector{"test"}},
+							ConfigMap: &trustapi.SourceObjectKeySelector{Name: "test", KeySelector: trustapi.KeySelector{Key: "test"}},
 							InLine:    pointer.String("test"),
 						},
 						{InLine: pointer.String("test")},
 						{
-							ConfigMap: &trustapi.SourceObjectKeySelector{"test", trustapi.KeySelector{"test"}},
-							Secret:    &trustapi.SourceObjectKeySelector{"test", trustapi.KeySelector{"test"}},
+							ConfigMap: &trustapi.SourceObjectKeySelector{Name: "test", KeySelector: trustapi.KeySelector{Key: "test"}},
+							Secret:    &trustapi.SourceObjectKeySelector{Name: "test", KeySelector: trustapi.KeySelector{Key: "test"}},
 						},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test"}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test"}},
 				},
 			},
 			expEl: field.ErrorList{
@@ -272,11 +272,11 @@ func Test_validateBundle(t *testing.T) {
 			bundle: &trustapi.Bundle{
 				Spec: trustapi.BundleSpec{
 					Sources: []trustapi.BundleSource{
-						{ConfigMap: &trustapi.SourceObjectKeySelector{"", trustapi.KeySelector{""}}},
+						{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "", KeySelector: trustapi.KeySelector{Key: ""}}},
 						{InLine: pointer.String("test")},
-						{Secret: &trustapi.SourceObjectKeySelector{"", trustapi.KeySelector{""}}},
+						{Secret: &trustapi.SourceObjectKeySelector{Name: "", KeySelector: trustapi.KeySelector{Key: ""}}},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test"}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test"}},
 				},
 			},
 			expEl: field.ErrorList{
@@ -292,9 +292,9 @@ func Test_validateBundle(t *testing.T) {
 				Spec: trustapi.BundleSpec{
 					Sources: []trustapi.BundleSource{
 						{InLine: pointer.String("test")},
-						{ConfigMap: &trustapi.SourceObjectKeySelector{"test-bundle", trustapi.KeySelector{"test"}}},
+						{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "test-bundle", KeySelector: trustapi.KeySelector{Key: "test"}}},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test"}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test"}},
 				},
 			},
 			expEl: field.ErrorList{
@@ -307,7 +307,7 @@ func Test_validateBundle(t *testing.T) {
 					Sources: []trustapi.BundleSource{
 						{InLine: pointer.String("test")},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{""}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: ""}},
 				},
 			},
 			expEl: field.ErrorList{
@@ -321,7 +321,7 @@ func Test_validateBundle(t *testing.T) {
 					Sources: []trustapi.BundleSource{
 						{InLine: pointer.String("test-1")},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test-1"}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test-1"}},
 				},
 			},
 			existingBundles: []runtime.Object{
@@ -331,7 +331,7 @@ func Test_validateBundle(t *testing.T) {
 						Sources: []trustapi.BundleSource{
 							{InLine: pointer.String("test-2")},
 						},
-						Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test-2"}},
+						Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test-2"}},
 					},
 				},
 			},
@@ -344,7 +344,7 @@ func Test_validateBundle(t *testing.T) {
 					Sources: []trustapi.BundleSource{
 						{InLine: pointer.String("test-1")},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test-1"}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test-1"}},
 				},
 			},
 			existingBundles: []runtime.Object{
@@ -354,7 +354,7 @@ func Test_validateBundle(t *testing.T) {
 						Sources: []trustapi.BundleSource{
 							{InLine: pointer.String("test-2")},
 						},
-						Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test-1"}},
+						Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test-1"}},
 					},
 				},
 			},
@@ -369,7 +369,7 @@ func Test_validateBundle(t *testing.T) {
 					Sources: []trustapi.BundleSource{
 						{InLine: pointer.String("test-1")},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test-1"}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test-1"}},
 				},
 				Status: trustapi.BundleStatus{
 					Conditions: []trustapi.BundleCondition{
@@ -395,7 +395,7 @@ func Test_validateBundle(t *testing.T) {
 					Sources: []trustapi.BundleSource{
 						{InLine: pointer.String("test-1")},
 					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{"test-1"}},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test-1"}},
 				},
 				Status: trustapi.BundleStatus{
 					Conditions: []trustapi.BundleCondition{

--- a/test/env/data.go
+++ b/test/env/data.go
@@ -99,15 +99,15 @@ func NewTestBundle(ctx context.Context, cl client.Client, opts bundle.Options, t
 			Sources: []trustapi.BundleSource{
 				{
 					ConfigMap: &trustapi.SourceObjectKeySelector{
-						configMap.Name,
-						trustapi.KeySelector{td.Sources.ConfigMap.Key},
+						Name:        configMap.Name,
+						KeySelector: trustapi.KeySelector{Key: td.Sources.ConfigMap.Key},
 					},
 				},
 
 				{
 					Secret: &trustapi.SourceObjectKeySelector{
-						secret.Name,
-						trustapi.KeySelector{td.Sources.Secret.Key},
+						Name:        secret.Name,
+						KeySelector: trustapi.KeySelector{Key: td.Sources.Secret.Key},
 					},
 				},
 


### PR DESCRIPTION
Adds `go vet ./...` as part of the Makefile `lint` target.

Fixes all the `go vet` linting errors.

/assign @SgtCoDFish 