### PR TITLE
Remove same bundle target key validation check 

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -31,7 +31,7 @@ type Options struct {
 func Register(mgr manager.Manager, opts Options) {
 	opts.Log.Info("registering webhook endpoints")
 
-	validator := &validator{log: opts.Log.WithName("validation"), lister: mgr.GetCache()}
+	validator := &validator{log: opts.Log.WithName("validation")}
 	mgr.GetWebhookServer().Register("/validate", &webhook.Admission{Handler: validator})
 	mgr.AddReadyzCheck("validator", validator.check)
 }


### PR DESCRIPTION
fixes #29 

Currently, we have validation in the admission webhook to ensure that Bundle targets cannot be the same as another Bundle target. This makes no sense, since Bundles are cluster scoped resources and resulting targets (today only ConfigMaps) are named, and therefore namespaced, by the Bundle themselves. There can only be a single target per Bundle.

Basically, the current validation makes no sense, and we should remove it.

---

As an aside, we _might_ now be able to push all of these validations into the API schema itself and do away with needing a networked admission webhook all together (:smile:).

/assign @jakexks 