### PR TITLE
docs: correct broken link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ not be known to cert-manager at all.
 ---
 
 Please follow the documentation at
-[cert-manager.io](https://cert-manager.io/docs/usage/trust/) for
+[cert-manager.io](https://cert-manager.io/docs/projects/trust/) for
 installing and using trust.


### PR DESCRIPTION
This corrects a broken link to the cert-manager.io doc site.
