### PR TITLE
Increase timeout for bundle integration tests for desired state from 10s to 30s

### DIFF
--- a/pkg/bundle/test/suite.go
+++ b/pkg/bundle/test/suite.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	eventuallyTimeout = "10s"
+	eventuallyTimeout = "30s"
 )
 
 var _ = Describe("Integration", func() {


### PR DESCRIPTION
I have started seeing quite a few transient test errors in CI because some integration test didn't reach a desired state in time.

This _may_ be because the CI runner is resource constrained, so I have increased the timeout here. Will watch this PR for a bit to see if this improves things or we have an actual bug here.

For me, running the tests locally always works.

/hold