### PR TITLE
add restrictive securitycontext for controller pod

### DIFF
--- a/deploy/charts/trust/templates/deployment.yaml
+++ b/deploy/charts/trust/templates/deployment.yaml
@@ -34,24 +34,27 @@ spec:
           - "--metrics-port={{.Values.app.metrics.port}}"
           - "--readiness-probe-port={{.Values.app.readinessProbe.port}}"
           - "--readiness-probe-path={{.Values.app.readinessProbe.path}}"
-
             # trust
           - "--trust-namespace={{.Values.app.trust.namespace}}"
-
             # webhook
           - "--webhook-host={{.Values.app.webhook.host}}"
           - "--webhook-port={{.Values.app.webhook.port}}"
           - "--webhook-certificate-dir=/tls"
-
-
         volumeMounts:
         - mountPath: /tls
           name: tls
           readOnly: true
-
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
-
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: tls
         secret:


### PR DESCRIPTION
Currently if we run `make e2e-setup-certmanager` in a cert-manager checkout, we'll install kyverno which will insist on a restrictive security context. That makes a lot of sense, and there's no reason we couldn't use the same restrictive context here.

This also adds `readOnlyRootFilesystem: true` which seems to work fine locally and seems a worthwhile thing to set early if we possibly can!