### PR TITLE
Updates Helm chart version to v0.1.2

### DIFF
--- a/deploy/charts/trust/Chart.yaml
+++ b/deploy/charts/trust/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/trust
 
 appVersion: v0.1.0
-version: v0.1.1
+version: v0.1.2

--- a/deploy/charts/trust/README.md
+++ b/deploy/charts/trust/README.md
@@ -1,6 +1,6 @@
 # cert-manager-trust
 
-![Version: v0.1.1](https://img.shields.io/badge/Version-v0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: v0.1.2](https://img.shields.io/badge/Version-v0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 A Helm chart for cert-manager-trust
 


### PR DESCRIPTION
Updates helm chart version to v0.1.2 after  https://github.com/cert-manager/trust/pull/47

Signed-off-by: joshvanl <me@joshvanl.dev>