### PR TITLE
Update go to v1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the trust binary
-FROM docker.io/library/golang:1.18 as builder
+FROM docker.io/library/golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/trust
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.6
 	k8s.io/apimachinery v0.23.6
 	k8s.io/cli-runtime v0.23.6
@@ -80,7 +81,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/tools/hack/tools
 
-go 1.18
+go 1.19
 
 require github.com/norwoodj/helm-docs v1.10.0
 


### PR DESCRIPTION
Signed-off-by: joshvanl <me@joshvanl.dev>

Updates go modules and Docker image golang version to v1.19

/hold
Until [jetstack/testing](https://github.com/jetstack/testing/tree/master/config/jobs) has been updated