### PR TITLE
Update Certificate resource to include issuerRef and group.

### DIFF
--- a/deploy/charts/trust-manager/Chart.yaml
+++ b/deploy/charts/trust-manager/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/trust-manager
 
 appVersion: v0.2.0
-version: v0.2.0
+version: v0.2.1

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -1,6 +1,6 @@
 # trust-manager
 
-![Version: v0.2.0](https://img.shields.io/badge/Version-v0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: v0.2.1](https://img.shields.io/badge/Version-v0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for trust-manager
 

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -20,3 +20,5 @@ spec:
   revisionHistoryLimit: 1
   issuerRef:
     name: {{ include "trust-manager.name" . }}
+    kind: Issuer
+    group: cert-manager.io


### PR DESCRIPTION
Update Certificate resource used for webhook with self-signed issuer to include issuerRef and group. This is to avoid the BadConfig warning that gets logged when CertificateRequest resource is created. Resolves #56 

Signed-off-by: Sitaram IYER <sitaramkm@gmail.com>